### PR TITLE
BAP-4: allow search in nested control scopes from Page or Global context

### DIFF
--- a/Services/Mapping/IMarkupStorage.cs
+++ b/Services/Mapping/IMarkupStorage.cs
@@ -11,5 +11,6 @@ namespace Behavioral.Automation.Services.Mapping
         IMarkupStorage TryGetControlScopeMarkupStorage(ControlScopeId controlScopeId);
 
         IMarkupStorage CreateControlScopeMarkupStorage(ControlScopeId controlScopeId);
+        ControlDescription TryFindInNestedScopes(string type, string name);
     }
 }

--- a/Services/Mapping/MarkupStorage.cs
+++ b/Services/Mapping/MarkupStorage.cs
@@ -46,8 +46,8 @@ namespace Behavioral.Automation.Services.Mapping
             {
                 var controlDescription = _mapping.Values.Where(composition => composition.Aliases.Contains(alias))
                     .SelectMany(composition => composition.Descriptions)
-                    .SingleOrDefault(desciption =>
-                        string.Equals(desciption.Caption, caption, StringComparison.OrdinalIgnoreCase));
+                    .SingleOrDefault(description =>
+                        string.Equals(description.Caption, caption, StringComparison.OrdinalIgnoreCase));
 
                 return controlDescription;
             }
@@ -93,7 +93,6 @@ namespace Behavioral.Automation.Services.Mapping
                 {
                     return controlDescription;
                 }
-
             }
             return null;
         }

--- a/Services/Mapping/MarkupStorage.cs
+++ b/Services/Mapping/MarkupStorage.cs
@@ -42,12 +42,19 @@ namespace Behavioral.Automation.Services.Mapping
 
         public ControlDescription TryFind(string alias, string caption)
         {
-            try{
-            return _mapping.Values.Where(composition => composition.Aliases.Contains(alias))
-                .SelectMany(composition => composition.Descriptions)
-                .SingleOrDefault(desciption => string.Equals(desciption.Caption, caption, StringComparison.OrdinalIgnoreCase));
-            } catch (InvalidOperationException ex) {
-                throw new InvalidOperationException($"More than one mapping is found for alias {alias} and caption {caption}", ex);
+            try
+            {
+                var controlDescription = _mapping.Values.Where(composition => composition.Aliases.Contains(alias))
+                    .SelectMany(composition => composition.Descriptions)
+                    .SingleOrDefault(desciption =>
+                        string.Equals(desciption.Caption, caption, StringComparison.OrdinalIgnoreCase));
+
+                return controlDescription;
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new InvalidOperationException(
+                    $"More than one mapping is found for alias {alias} and caption {caption}", ex);
             }
         }
 
@@ -73,6 +80,22 @@ namespace Behavioral.Automation.Services.Mapping
             IMarkupStorage controlMarkupStorage = new MarkupStorage();
             _nestedScopeToMarkupMap.Add(controlScopeId, controlMarkupStorage);
             return controlMarkupStorage;
+        }
+
+        public ControlDescription TryFindInNestedScopes(string type, string name)
+        {
+            foreach (var nestedScope in _nestedScopeToMarkupMap.Values)
+            {
+                var controlDescription = nestedScope.TryFind(type, name)
+                                         ?? nestedScope.TryFindInNestedScopes(type, name);
+
+                if (controlDescription != null)
+                {
+                    return controlDescription;
+                }
+
+            }
+            return null;
         }
 
         private class ControlComposition

--- a/Services/Mapping/PageScopeContext.cs
+++ b/Services/Mapping/PageScopeContext.cs
@@ -27,7 +27,9 @@ namespace Behavioral.Automation.Services.Mapping
             var controlDescription = _markupStorage?.TryFind(type,
                                          name) ??
                                      _globalMarkupStorage.TryFind(type,
-                                         name);
+                                         name)
+                                     ?? _markupStorage?.TryFindInNestedScopes(type, name)
+                                     ?? _globalMarkupStorage.TryFindInNestedScopes(type, name);
 
             if (controlDescription == null)
             {


### PR DESCRIPTION
Lets assume there is a control 'Categories' list that is defined as part of ControlScope with name 'Categories panel'.
Currently, there is only one way to access 'Categories' list control: by using 'inside' binding.

**Example:**
`inside 'Categories' panel: 'Categories' list is visible`

We need another way for accessing controls defined in ControlScope from Page\Global context level.
**Example of expected syntax for access control:**
`'Categories' list is visible`

**AC:**
* When referenced element is not found in Page\Global context, then BDD Framework should search recursively for an element inside Control scopes. 

