### PR TITLE
Feature/bap 7 define virtualized scope

### DIFF
--- a/Services/Mapping/Contract/IControlScopeContext.cs
+++ b/Services/Mapping/Contract/IControlScopeContext.cs
@@ -1,0 +1,7 @@
+namespace Behavioral.Automation.Services.Mapping.Contract
+{
+    public interface IControlScopeContext: IScopeContext
+    {
+
+    }
+}

--- a/Services/Mapping/Contract/IScopeContext.cs
+++ b/Services/Mapping/Contract/IScopeContext.cs
@@ -3,6 +3,6 @@
     public interface IScopeContext
     {
         ControlDescription FindControlDescription(string type, string name);
-        ControlScopeContext GetNestedControlScopeContext(ControlScopeId controlScopeId);
+        IControlScopeContext GetNestedControlScopeContext(ControlScopeId controlScopeId);
     }
 }

--- a/Services/Mapping/Contract/IScopeMappingPipe.cs
+++ b/Services/Mapping/Contract/IScopeMappingPipe.cs
@@ -5,6 +5,6 @@ namespace Behavioral.Automation.Services.Mapping.Contract
     public interface IScopeMappingPipe : IDisposable
     {
         IHtmlTagMapper Register(string tag);
-        IScopeMappingPipe CreateControlMappingPipe(ControlScopeId controlScopeId);
+        IScopeMappingPipe CreateControlMappingPipe(ControlScopeId controlScopeId, ControlScopeOptions controlScopeOptions = null);
     }
 }

--- a/Services/Mapping/Contract/IScopeMappingPipe.cs
+++ b/Services/Mapping/Contract/IScopeMappingPipe.cs
@@ -6,5 +6,7 @@ namespace Behavioral.Automation.Services.Mapping.Contract
     {
         IHtmlTagMapper Register(string tag);
         IScopeMappingPipe CreateControlMappingPipe(ControlScopeId controlScopeId, ControlScopeOptions controlScopeOptions = null);
+
+        IScopeMappingPipe CreateControlMappingPipe(string controlScopeId, bool isVirtualized = false);
     }
 }

--- a/Services/Mapping/Contract/IVirtualizedScopeContext.cs
+++ b/Services/Mapping/Contract/IVirtualizedScopeContext.cs
@@ -1,0 +1,7 @@
+namespace Behavioral.Automation.Services.Mapping.Contract
+{
+    public interface IVirtualizedScopeContext: IControlScopeContext
+    {
+
+    }
+}

--- a/Services/Mapping/ControlScopeContext.cs
+++ b/Services/Mapping/ControlScopeContext.cs
@@ -4,7 +4,7 @@ using JetBrains.Annotations;
 
 namespace Behavioral.Automation.Services.Mapping
 {
-    public sealed class ControlScopeContext : IScopeContext
+    public sealed class ControlScopeContext : IControlScopeContext
     {
         private readonly ControlScopeId _contextId;
 
@@ -31,7 +31,7 @@ namespace Behavioral.Automation.Services.Mapping
             return controlDescription;
         }
 
-        public ControlScopeContext GetNestedControlScopeContext(ControlScopeId controlScopeId)
+        public IControlScopeContext GetNestedControlScopeContext(ControlScopeId controlScopeId)
         {
             if (_markupStorage == null)
             {
@@ -41,6 +41,11 @@ namespace Behavioral.Automation.Services.Mapping
 
             var nestedControlMarkupStorage = _markupStorage.TryGetControlScopeMarkupStorage(controlScopeId) ??
                                              _markupStorage.CreateControlScopeMarkupStorage(controlScopeId);
+
+            if (nestedControlMarkupStorage.ScopeOptions.IsVirtualized)
+            {
+                return new VirtualizedControlScopeContext(controlScopeId, nestedControlMarkupStorage);
+            }
 
             return new ControlScopeContext(controlScopeId, nestedControlMarkupStorage);
         }

--- a/Services/Mapping/ControlScopeOptions.cs
+++ b/Services/Mapping/ControlScopeOptions.cs
@@ -1,0 +1,20 @@
+namespace Behavioral.Automation.Services.Mapping
+{
+    public sealed class ControlScopeOptions
+    {
+
+        private static readonly ControlScopeOptions DefaultOptions = new ControlScopeOptions();
+
+        public ControlScopeOptions(bool isVirtualized = false)
+        {
+            IsVirtualized = isVirtualized;
+        }
+
+        public bool IsVirtualized { get; }
+
+        public static ControlScopeOptions Default()
+        {
+            return DefaultOptions;
+        }
+    }
+}

--- a/Services/Mapping/IMarkupStorage.cs
+++ b/Services/Mapping/IMarkupStorage.cs
@@ -10,7 +10,10 @@ namespace Behavioral.Automation.Services.Mapping
         [CanBeNull]
         IMarkupStorage TryGetControlScopeMarkupStorage(ControlScopeId controlScopeId);
 
-        IMarkupStorage CreateControlScopeMarkupStorage(ControlScopeId controlScopeId);
+        IMarkupStorage CreateControlScopeMarkupStorage(ControlScopeId controlScopeId, ControlScopeOptions controlScopeOptions = null);
+
         ControlDescription TryFindInNestedScopes(string type, string name);
+
+        public ControlScopeOptions ScopeOptions { get; }
     }
 }

--- a/Services/Mapping/IMarkupStorageInitializer.cs
+++ b/Services/Mapping/IMarkupStorageInitializer.cs
@@ -12,6 +12,7 @@ namespace Behavioral.Automation.Services.Mapping
             [NotNull] string caption,
             [CanBeNull] string subpath = null);
 
-        IMarkupStorageInitializer GetOrCreateControlScopeMarkupStorage(ControlScopeId controlScopeId);
+        IMarkupStorageInitializer GetOrCreateControlScopeMarkupStorage(ControlScopeId controlScopeId,
+            ControlScopeOptions controlScopeOptions = null);
     }
 }

--- a/Services/Mapping/MarkupStorage.cs
+++ b/Services/Mapping/MarkupStorage.cs
@@ -13,10 +13,13 @@ namespace Behavioral.Automation.Services.Mapping
         private readonly Dictionary<ControlScopeId, IMarkupStorage> _nestedScopeToMarkupMap =
             new Dictionary<ControlScopeId, IMarkupStorage>();
 
-        public MarkupStorage()
+        public MarkupStorage([CanBeNull] ControlScopeOptions controlScopeOptions = null)
         {
             _mapping = new Dictionary<string, ControlComposition>();
+            ScopeOptions = controlScopeOptions ?? ControlScopeOptions.Default();
         }
+
+        public ControlScopeOptions ScopeOptions { get; }
 
         public void AddAlias(string htmlTag, params string[] aliases)
         {
@@ -58,12 +61,13 @@ namespace Behavioral.Automation.Services.Mapping
             }
         }
 
-        public IMarkupStorageInitializer GetOrCreateControlScopeMarkupStorage(ControlScopeId controlScopeId)
+        public IMarkupStorageInitializer GetOrCreateControlScopeMarkupStorage(ControlScopeId controlScopeId,
+            ControlScopeOptions controlScopeOptions = null)
         {
             IMarkupStorageInitializer controlMarkupStorage = TryGetControlScopeMarkupStorage(controlScopeId);
             if (controlMarkupStorage == null)
             {
-                controlMarkupStorage = CreateControlScopeMarkupStorage(controlScopeId);
+                controlMarkupStorage = CreateControlScopeMarkupStorage(controlScopeId, controlScopeOptions);
             }
 
             return controlMarkupStorage;
@@ -75,9 +79,9 @@ namespace Behavioral.Automation.Services.Mapping
             return controlMarkupStorage;
         }
 
-        public IMarkupStorage CreateControlScopeMarkupStorage(ControlScopeId controlScopeId)
+        public IMarkupStorage CreateControlScopeMarkupStorage(ControlScopeId controlScopeId, ControlScopeOptions controlScopeOptions = null)
         {
-            IMarkupStorage controlMarkupStorage = new MarkupStorage();
+            IMarkupStorage controlMarkupStorage = new MarkupStorage(controlScopeOptions);
             _nestedScopeToMarkupMap.Add(controlScopeId, controlMarkupStorage);
             return controlMarkupStorage;
         }

--- a/Services/Mapping/MultiMarkupStorageProxy.cs
+++ b/Services/Mapping/MultiMarkupStorageProxy.cs
@@ -28,10 +28,11 @@ namespace Behavioral.Automation.Services.Mapping
             }
         }
 
-        public IMarkupStorageInitializer GetOrCreateControlScopeMarkupStorage(ControlScopeId controlScopeId)
+        public IMarkupStorageInitializer GetOrCreateControlScopeMarkupStorage(ControlScopeId controlScopeId,
+            ControlScopeOptions controlScopeOptions = null)
         {
             return new MultiMarkupStorageProxy(_storages
-                .Select(v => v.GetOrCreateControlScopeMarkupStorage(controlScopeId)));
+                .Select(v => v.GetOrCreateControlScopeMarkupStorage(controlScopeId, controlScopeOptions)));
         }
     }
 }

--- a/Services/Mapping/PageScopeContext.cs
+++ b/Services/Mapping/PageScopeContext.cs
@@ -40,7 +40,7 @@ namespace Behavioral.Automation.Services.Mapping
             return controlDescription;
         }
 
-        public ControlScopeContext GetNestedControlScopeContext(ControlScopeId controlScopeId)
+        public IControlScopeContext GetNestedControlScopeContext(ControlScopeId controlScopeId)
         {
             if (_markupStorage == null)
             {
@@ -52,9 +52,16 @@ namespace Behavioral.Automation.Services.Mapping
                                              _globalMarkupStorage.TryGetControlScopeMarkupStorage(controlScopeId)) ??
                                             _markupStorage.CreateControlScopeMarkupStorage(controlScopeId);
 
-            return new ControlScopeContext(controlScopeId, controlScopeMarkupStorage);
+            if (controlScopeMarkupStorage.ScopeOptions.IsVirtualized)
+            {
+                return new VirtualizedControlScopeContext(controlScopeId, controlScopeMarkupStorage);
+            }
+            else
+            {
+                return new ControlScopeContext(controlScopeId, controlScopeMarkupStorage);
+            }
         }
-        
+
         public PageScopeId ScopeId { get; }
     }
 }

--- a/Services/Mapping/ScopeMappingPipe.cs
+++ b/Services/Mapping/ScopeMappingPipe.cs
@@ -21,6 +21,11 @@ namespace Behavioral.Automation.Services.Mapping
             return new ScopeMappingPipe(_markupStorage.GetOrCreateControlScopeMarkupStorage(controlScopeId, controlScopeOptions));
         }
 
+        public IScopeMappingPipe CreateControlMappingPipe(string controlScopeId, bool isVirtualized = false)
+        {
+            return CreateControlMappingPipe(new ControlScopeId(controlScopeId), new ControlScopeOptions(isVirtualized));
+        }
+
 
         public void Dispose()
         {

--- a/Services/Mapping/ScopeMappingPipe.cs
+++ b/Services/Mapping/ScopeMappingPipe.cs
@@ -16,9 +16,9 @@ namespace Behavioral.Automation.Services.Mapping
             return new HtmlTagMapper(_markupStorage, tag);
         }
 
-        public IScopeMappingPipe CreateControlMappingPipe(ControlScopeId controlScopeId)
+        public IScopeMappingPipe CreateControlMappingPipe(ControlScopeId controlScopeId, ControlScopeOptions controlScopeOptions = null)
         {
-            return new ScopeMappingPipe(_markupStorage.GetOrCreateControlScopeMarkupStorage(controlScopeId));
+            return new ScopeMappingPipe(_markupStorage.GetOrCreateControlScopeMarkupStorage(controlScopeId, controlScopeOptions));
         }
 
 

--- a/Services/Mapping/VirtualizedControlScopeContext.cs
+++ b/Services/Mapping/VirtualizedControlScopeContext.cs
@@ -1,0 +1,26 @@
+using Behavioral.Automation.Services.Mapping.Contract;
+using JetBrains.Annotations;
+
+namespace Behavioral.Automation.Services.Mapping
+{
+    public sealed class VirtualizedControlScopeContext : IVirtualizedScopeContext
+    {
+        private readonly ControlScopeContext _controlScopeContext;
+
+        public VirtualizedControlScopeContext(ControlScopeId contextId,
+            [CanBeNull] IMarkupStorage markupStorage)
+        {
+            _controlScopeContext = new ControlScopeContext(contextId, markupStorage);
+        }
+
+        public ControlDescription FindControlDescription(string type, string name)
+        {
+            return _controlScopeContext.FindControlDescription(type, name);
+        }
+
+        public IControlScopeContext GetNestedControlScopeContext(ControlScopeId controlScopeId)
+        {
+            return _controlScopeContext.GetNestedControlScopeContext(controlScopeId);
+        }
+    }
+}


### PR DESCRIPTION
Added configuration parameter to ControlScope called 'isVirtualized'.
When ControlScope has parameter 'isVirtualized' = True, then the corresponding element can be scrolled to load and find nested elements. 

So, the idea is that virtualized lists\tables\.etc should be declared in UserInterfaceBuilder:
1) as element in page context\control context.
2) as ControlScope with 'isVirtualized' parameter set to true. 

Example:
<img width="879" alt="image" src="https://user-images.githubusercontent.com/68227135/93618917-9968e380-f9e0-11ea-8c0b-331f54f2e4f0.png">
