### PR TITLE
BAP-2: fix loading of same element multiple times and scrolling of element without virtualized scope

### DIFF
--- a/src/Behavioral.Automation/Services/IVirtualizedElementsSelectionService.cs
+++ b/src/Behavioral.Automation/Services/IVirtualizedElementsSelectionService.cs
@@ -9,6 +9,6 @@ namespace Behavioral.Automation.Services
         IEnumerable<T> FindVirtualized<T>(string caption,
             LoadElementsFromCurrentViewCallback<T> loadElementsCallback) where T : IWebElementWrapper;
 
-        bool IsVirtualizable(string caption);
+        bool ControlIsVirtualizable(string caption);
     }
 }

--- a/src/Behavioral.Automation/Services/Mapping/IScopeContextRuntime.cs
+++ b/src/Behavioral.Automation/Services/Mapping/IScopeContextRuntime.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 using TechTalk.SpecFlow;
 using TechTalk.SpecFlow.Bindings;
 
@@ -13,5 +14,6 @@ namespace Behavioral.Automation.Services.Mapping
         void SwitchToGlobalScope();
         void RunAction(string action, StepDefinitionType stepDefinitionType);
         void RunAction(string action, StepDefinitionType stepDefinitionType, Table table);
+        bool HasVirtualizedScopeContext(ControlScopeId controlScopeId, [CanBeNull] ControlScopeId parenControlScopeId);
     }
 }

--- a/src/Behavioral.Automation/Services/Mapping/MarkupStorage.cs
+++ b/src/Behavioral.Automation/Services/Mapping/MarkupStorage.cs
@@ -86,7 +86,7 @@ namespace Behavioral.Automation.Services.Mapping
         public IMarkupStorage CreateControlScopeMarkupStorage(ControlScopeId controlScopeId, ControlScopeOptions controlScopeOptions = null)
         {
             IMarkupStorage controlMarkupStorage = new MarkupStorage(controlScopeOptions,
-                new ControlLocation(controlScopeId, controlScopeOptions, _controlLocation));
+                new ControlLocation(controlScopeId, controlScopeOptions ?? new ControlScopeOptions(), _controlLocation));
             _nestedScopeToMarkupMap.Add(controlScopeId, controlMarkupStorage);
             return controlMarkupStorage;
         }

--- a/src/Behavioral.Automation/Services/Mapping/ScopeContextRuntime.cs
+++ b/src/Behavioral.Automation/Services/Mapping/ScopeContextRuntime.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Behavioral.Automation.Services.Mapping.Contract;
 using Behavioral.Automation.Services.Mapping.PageMapping;
+using JetBrains.Annotations;
 using TechTalk.SpecFlow;
 using TechTalk.SpecFlow.Bindings;
 
@@ -18,7 +19,10 @@ namespace Behavioral.Automation.Services.Mapping
         {
             _runner = runner;
             _globalContext =
-                new PageScopeContext(new PageScopeId(string.Empty, string.Empty), container.GetGlobal());
+                new PageScopeContext(
+                    new PageScopeId(string.Empty, string.Empty), 
+                    container.GetGlobal(), 
+                    new MarkupStorage());
             _contextStack.Push(_globalContext);
         }
 
@@ -76,6 +80,13 @@ namespace Behavioral.Automation.Services.Mapping
                 default:
                     throw new ArgumentOutOfRangeException(nameof(stepDefinitionType), stepDefinitionType, null);
             }
+        }
+
+        public bool HasVirtualizedScopeContext(ControlScopeId controlScopeId, ControlScopeId parentControlScopeId = null)
+        {
+            var parentControlScope = parentControlScopeId != null ? CurrentContext.GetNestedControlScopeContext(parentControlScopeId): CurrentContext;
+            var nestedScope = parentControlScope.GetNestedControlScopeContext(controlScopeId);
+            return nestedScope is IVirtualizedScopeContext;
         }
 
 


### PR DESCRIPTION
This pull request contains two changes:

1) Fixed loading of same virtualized element multiple times during scrolling (see GetElements<T> method in VirtualizedElementsSelectionService). Now we filter elements by ID to avoid duplicates. 

2) Sometimes list (or another element) that should be scrolled is referenced directly in bindings, so the approach with virtualized scopes was not working. 
_Example of mapping that shows the problem:_
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/68227135/94527470-afc43a00-023f-11eb-96e3-3b37e00ea85a.png">(If you define elements inside mapping, then in time of access to those elements in scenario, the 'Categories' list will be scrolled correctly. 
!!! But if you reference 'Categories' list in scenario directly, scrolling will not work:
_Example of scenario that will fire an exception due to this problem:_
<img width="510" alt="image" src="https://user-images.githubusercontent.com/68227135/94527651-f9148980-023f-11eb-879f-5106d1a950d3.png">
**Now this problem is fixed in the following way:**
when framework processes a collection and detects corresponding virtualized scope, it allows scrolling of that collection. 