### PR TITLE
BAP-44: add project for demo scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 obj
 .vs
 .vscode
+*.feature.cs

--- a/Behavioral.Automation.DemoBindings/AutomationConfig.json
+++ b/Behavioral.Automation.DemoBindings/AutomationConfig.json
@@ -1,0 +1,12 @@
+﻿{
+  "BASE_URL": "http://localhost:4200/",
+  "TEST_EMAIL": "",
+  "TEST_PASSWORD": "",
+  "BASE_AUTH_URL": "",
+  "BROWSER_PARAMS": "--window-size=1920,1080",
+  "DOWNLOAD_PATH": "",
+  "SEARCH_ATTRIBUTE": "automation-id",
+  "BAUTH_LOGIN": "",
+  "BAUTH_PWD": "",
+  "BAUTH_IGNORE": "true"
+}

--- a/Behavioral.Automation.DemoBindings/Behavioral.Automation.DemoBindings.csproj
+++ b/Behavioral.Automation.DemoBindings/Behavioral.Automation.DemoBindings.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<IsPackable>false</IsPackable>
+	<Authors>Quantori Inc.</Authors>
+	<Description>Demo project that can be used as example of test configuration.</Description>
+	<RepositoryUrl>https://github.com/quantori/Behavioral.Automation</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Selenium.Support" Version="3.141.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="SpecFlow" Version="3.1.97" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Behavioral.Automation\Behavioral.Automation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="AutomationConfig.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Behavioral.Automation.DemoBindings/Bindings/ElementTransformations.cs
+++ b/Behavioral.Automation.DemoBindings/Bindings/ElementTransformations.cs
@@ -1,0 +1,31 @@
+﻿using Behavioral.Automation.DemoBindings.Elements;
+using Behavioral.Automation.Elements;
+using Behavioral.Automation.Services;
+using JetBrains.Annotations;
+using TechTalk.SpecFlow;
+
+namespace Behavioral.Automation.DemoBindings.Bindings
+{
+    [Binding]
+    class ElementTransformations
+    {
+        private readonly IDriverService _driverService;
+        private readonly IElementSelectionService _selectionService;
+
+        public ElementTransformations(
+            [NotNull] IDriverService driverService,
+            [NotNull] IElementSelectionService selectionService)
+        {
+            _driverService = driverService;
+            _selectionService = selectionService;
+        }
+
+        [StepArgumentTransformation]
+        public IWebElementWrapper FindElement([NotNull] string caption)
+        {
+            return new WebElementWrapper(() => _selectionService.Find(caption),
+                caption,
+                _driverService);
+        }
+    }
+}

--- a/Behavioral.Automation.DemoBindings/Bootstrapper.cs
+++ b/Behavioral.Automation.DemoBindings/Bootstrapper.cs
@@ -1,0 +1,44 @@
+﻿using Behavioral.Automation.FluentAssertions;
+using Behavioral.Automation.Services;
+using BoDi;
+using TechTalk.SpecFlow;
+
+namespace Behavioral.Automation.DemoBindings
+{
+    [Binding]
+    public class Bootstrapper
+    {
+        private readonly IObjectContainer _objectContainer;
+        private readonly ITestRunner _runner;
+        private static DemoTestServicesBuilder _servicesBuilder;
+        private static readonly BrowserRunner BrowserRunner = new BrowserRunner();
+
+        public Bootstrapper(IObjectContainer objectContainer, ITestRunner runner)
+        {
+            _objectContainer = objectContainer;
+            _runner = runner;
+            _servicesBuilder = new DemoTestServicesBuilder(objectContainer, new TestServicesBuilder(_objectContainer));
+        }
+
+        [BeforeTestRun]
+        public static void OpenBrowser()
+        {
+            BrowserRunner.OpenChrome();
+        }
+
+        [AfterTestRun]
+        public static void CloseBrowser()
+        {
+            BrowserRunner.CloseBrowser();
+        }
+
+        [BeforeScenario(Order = 0)]
+        public void Bootstrap()
+        {
+            Assert.SetRunner(_runner);
+            _objectContainer.RegisterTypeAs<UserInterfaceBuilder, IUserInterfaceBuilder>();
+            _servicesBuilder.Build();
+            Assert.SetConsumer(_objectContainer.Resolve<IScenarioExecutionConsumer>());
+        }
+    }
+}

--- a/Behavioral.Automation.DemoBindings/DemoTestServicesBuilder.cs
+++ b/Behavioral.Automation.DemoBindings/DemoTestServicesBuilder.cs
@@ -1,0 +1,21 @@
+﻿using BoDi;
+
+namespace Behavioral.Automation.DemoBindings
+{
+    internal class DemoTestServicesBuilder
+    {
+        private readonly IObjectContainer _objectContainer;
+        private readonly TestServicesBuilder _servicesBuilder;
+
+        internal DemoTestServicesBuilder(IObjectContainer objectContainer, TestServicesBuilder servicesBuilder)
+        {
+            _objectContainer = objectContainer;
+            _servicesBuilder = servicesBuilder;
+        }
+
+        internal void Build()
+        {
+            _servicesBuilder.Build();
+        }
+    }
+}

--- a/Behavioral.Automation.DemoBindings/Elements/WebElementWrapper.cs
+++ b/Behavioral.Automation.DemoBindings/Elements/WebElementWrapper.cs
@@ -1,0 +1,122 @@
+﻿using Behavioral.Automation.Elements;
+using Behavioral.Automation.FluentAssertions;
+using Behavioral.Automation.Services;
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Behavioral.Automation.DemoBindings.Elements
+{
+    public class WebElementWrapper : IWebElementWrapper
+    {
+        private readonly Func<IWebElement> _elementSelector;
+        private readonly IDriverService _driverService;
+
+        public WebElementWrapper([NotNull] Func<IWebElement> elementSelector, [NotNull] string caption, [NotNull] IDriverService driverService)
+        {
+            _elementSelector = elementSelector;
+            _driverService = driverService;
+            Caption = caption;
+        }
+
+        public string Caption { get; }
+
+        public IWebElement Element => _elementSelector();
+
+        public string Text => Element.Text;
+
+        public string GetAttribute(string attribute) => Element.GetAttribute(attribute);
+
+        public void Click()
+        {
+            MouseHover();
+            Assert.ShouldGet(() => Enabled);
+            _driverService.MouseClick();
+        }
+
+        public void MouseHover()
+        {
+            Assert.ShouldBecome(() => Enabled, true, $"{Caption} is disabled");
+            _driverService.ScrollTo(Element);
+        }
+
+        public void SendKeys(string text)
+        {
+            Assert.ShouldBecome(() => Enabled, true, $"{Caption} is disabled");
+            Element.SendKeys(text);
+        }
+
+        public bool Displayed => Element != null && Element.Displayed;
+
+        public bool Enabled => Displayed && Element.Enabled && AriaEnabled;
+
+        public string Tooltip
+        {
+            get
+            {
+                var matTooltip = GetAttribute("matTooltip");
+                if (matTooltip != null)
+                {
+                    return matTooltip;
+                }
+                var ngReflectTip = GetAttribute("ng-reflect-message"); //some elements have their tooltips' texts stored inside 'ng-reflect-message' attribute
+                if (ngReflectTip != null)
+                {
+                    return ngReflectTip;
+                }
+
+                return GetAttribute("aria-label"); //some elements have their tooltips' texts stored inside 'aria-label' attribute
+            }
+        }
+
+        public bool Stale
+        {
+            get
+            {
+                try
+                {
+                    // Calling any method forces a staleness check
+                    var elementEnabled = Element.Enabled;
+                    return false;
+                }
+                catch (StaleElementReferenceException)
+                {
+                    return true;
+                }
+            }
+        }
+
+        public IEnumerable<IWebElementWrapper> FindSubElements(By locator, string caption)
+        {
+            var elements = Assert.ShouldGet(() => Element.FindElements(locator));
+            return ElementsToWrappers(elements, caption);
+        }
+
+        private IEnumerable<IWebElementWrapper> ElementsToWrappers(IEnumerable<IWebElement> elements, string caption)
+        {
+            foreach (var element in elements)
+            {
+                var wrapper = new WebElementWrapper(() => element, caption, _driverService);
+                yield return wrapper;
+            }
+        }
+
+        protected IDriverService Driver => _driverService;
+
+        private bool AriaEnabled
+        {
+            get
+            {
+                switch (Element.GetAttribute("aria-disabled"))
+                {
+                    case null:
+                    case "false":
+                        return true;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/Behavioral.Automation.DemoBindings/Services/UserInterfaceBuilder.cs
+++ b/Behavioral.Automation.DemoBindings/Services/UserInterfaceBuilder.cs
@@ -1,0 +1,23 @@
+﻿using Behavioral.Automation.Services;
+using Behavioral.Automation.Services.Mapping.Contract;
+
+namespace Behavioral.Automation.DemoBindings
+{
+    public class UserInterfaceBuilder : UserInterfaceBuilderBase
+    {
+        public UserInterfaceBuilder(IScopeMarkupMapper mapper)
+            : base(mapper)
+        {
+
+        }
+
+        public override void Build()
+        {
+            using (var mappingPipe = Mapper.GetGlobalMappingPipe())
+            {
+                mappingPipe.Register("label").Alias("label")
+                    .With("label-simple-text").As("Demo");
+            }
+        }
+    }
+}

--- a/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Authors>Quantori Inc.</Authors>
+    <Description>Specflow scenarios for demonstration of Behavioral.Automation framework features and testing.</Description>
+    <Copyright>Quantori Inc.</Copyright>
+    <RepositoryUrl>https://github.com/quantori/Behavioral.Automation</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+	<PackageReference Include="SpecFlow" Version="3.1.97" />
+	<PackageReference Include="SpecFlow.NUnit" Version="3.1.97" />
+	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Behavioral.Automation.DemoBindings\Behavioral.Automation.DemoBindings.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="specflow.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Behavioral.Automation.DemoScenarios/Features/LabelBinding.feature
+++ b/Behavioral.Automation.DemoScenarios/Features/LabelBinding.feature
@@ -1,0 +1,7 @@
+﻿Feature: LabelBinding
+
+@Automated
+Scenario: Label should contain expected text
+	Given application URL is opened
+	Then the "Demo" label text should be "Behavioral automation demo"
+	

--- a/Behavioral.Automation.DemoScenarios/specflow.json
+++ b/Behavioral.Automation.DemoScenarios/specflow.json
@@ -1,0 +1,19 @@
+﻿{
+  "bindingCulture": {
+    "language": "en-us"
+  },
+  "language": {
+    "feature": "en-us"
+  },
+  "runtime": {
+    "missingOrPendingStepsOutcome": "Error"
+  },
+  "stepAssemblies": [
+    {
+      "assembly": "Behavioral.Automation.DemoBindings"
+    },
+    {
+      "assembly": "Behavioral.Automation"
+    }
+  ]
+}

--- a/Behavioral.Automation.sln
+++ b/Behavioral.Automation.sln
@@ -8,6 +8,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Behavioral.Automation.UnitT
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Tests", "_Tests", "{BB7AC02C-03FD-4F17-B4A9-CDECC1A63DA5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Behavioral.Automation.DemoScenarios", "Behavioral.Automation.DemoScenarios\Behavioral.Automation.DemoScenarios.csproj", "{C7AF5750-75A5-4E8D-80FA-FB54914B0B17}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Behavioral.Automation.DemoBindings", "Behavioral.Automation.DemoBindings\Behavioral.Automation.DemoBindings.csproj", "{4DD5E62E-E447-419D-82BF-C918F08091BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,12 +26,22 @@ Global
 		{054B7FBC-190D-43FA-B6D6-13A2BA7CB92D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{054B7FBC-190D-43FA-B6D6-13A2BA7CB92D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{054B7FBC-190D-43FA-B6D6-13A2BA7CB92D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7AF5750-75A5-4E8D-80FA-FB54914B0B17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7AF5750-75A5-4E8D-80FA-FB54914B0B17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7AF5750-75A5-4E8D-80FA-FB54914B0B17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7AF5750-75A5-4E8D-80FA-FB54914B0B17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DD5E62E-E447-419D-82BF-C918F08091BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DD5E62E-E447-419D-82BF-C918F08091BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DD5E62E-E447-419D-82BF-C918F08091BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DD5E62E-E447-419D-82BF-C918F08091BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{054B7FBC-190D-43FA-B6D6-13A2BA7CB92D} = {BB7AC02C-03FD-4F17-B4A9-CDECC1A63DA5}
+		{C7AF5750-75A5-4E8D-80FA-FB54914B0B17} = {BB7AC02C-03FD-4F17-B4A9-CDECC1A63DA5}
+		{4DD5E62E-E447-419D-82BF-C918F08091BD} = {BB7AC02C-03FD-4F17-B4A9-CDECC1A63DA5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {724FD185-E1F2-44BD-89EA-DFD1DBF6453A}


### PR DESCRIPTION
Added almost empty project for demo scenarios. 
Now it contains 1 simple test for label, just to make sure configuration of project is working.

You can run the scenario "Label should contain expected text" if the demo site is running locally on your machine.
Demo site is not yet merged into develop branch, see corresponding PR:
https://github.com/quantori/Behavioral.Automation/pull/17

I have successfully run the scenario:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/68227135/96018075-7d2b5b80-0e53-11eb-983c-94a625fb9cc1.png">
