### PR TITLE
BAP-25: make alias an optional property for control mapping definition

### DIFF
--- a/src/Behavioral.Automation/Services/AutomationIDProvider.cs
+++ b/src/Behavioral.Automation/Services/AutomationIDProvider.cs
@@ -18,11 +18,20 @@ namespace Behavioral.Automation.Services
             ParseCaption(caption, out var name, out var type);
             return _scopeContextRuntime.FindControlDescription(type, name);
         }
-        public void ParseCaption(string caption, out string name,out string type)
+
+        public void ParseCaption(string caption, out string name, out string type)
         {
-            var result = caption.ParseExact("\"{0}\" {1}");
-            name = result[0];
-            type = result[1];
+            string[] parsedValues;
+            if (caption.TryParseExact("\"{0}\" {1}", out parsedValues, true))
+            {
+                name = parsedValues[0];
+                type = parsedValues[1];
+                return;
+            }
+            
+            parsedValues = caption.ParseExact("\"{0}\"",  true);
+            name = parsedValues[0];
+            type = string.Empty;
         }
     }
 }

--- a/src/Behavioral.Automation/Services/Mapping/MarkupStorage.cs
+++ b/src/Behavioral.Automation/Services/Mapping/MarkupStorage.cs
@@ -51,7 +51,18 @@ namespace Behavioral.Automation.Services.Mapping
         {
             try
             {
-                var controlDescription = _mapping.Values.Where(composition => composition.Aliases.Contains(alias))
+                IEnumerable<ControlComposition> controlCompositions;
+                if (alias == string.Empty)
+                {
+                    controlCompositions = _mapping.Values.Where(composition =>
+                        !composition.Aliases.Any() || composition.Aliases.Contains(alias));
+                }
+                else
+                {
+                    controlCompositions = _mapping.Values.Where(composition => composition.Aliases.Contains(alias));
+                }
+
+                var controlDescription = controlCompositions
                     .SelectMany(composition => composition.Descriptions)
                     .SingleOrDefault(description =>
                         string.Equals(description.Caption, caption, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
Now alias is an optional property for control mapping definition.
So, instead of writing:
<img width="468" alt="image" src="https://user-images.githubusercontent.com/68227135/96615090-84e27880-1309-11eb-9985-aac24a4590dc.png">

You can define elements like this:
<img width="407" alt="image" src="https://user-images.githubusercontent.com/68227135/96615128-94fa5800-1309-11eb-9374-923ab8ad32a2.png">

Or
<img width="408" alt="image" src="https://user-images.githubusercontent.com/68227135/96615182-a5123780-1309-11eb-9f80-4335daff151b.png">
