### PR TITLE
BAP-49: fix Attribute binding.

### DIFF
--- a/src/Behavioral.Automation/Bindings/AttributeBinding.cs
+++ b/src/Behavioral.Automation/Bindings/AttributeBinding.cs
@@ -18,8 +18,8 @@ namespace Behavioral.Automation.Bindings
             _runner = runner;
         }
 
-        [Given("(.*?) (is|is not|become| become not) (enabled|disabled)")]
-        [When("(.*?) (is|is not|become| become not) (enabled|disabled)")]
+        [Given("the (.*?) (is|is not|become| become not) (enabled|disabled)")]
+        [When("the (.*?) (is|is not|become| become not) (enabled|disabled)")]
         [Then("the (.*?) should (be|be not|become|become not) (enabled|disabled)")]
         public void CheckElementIsDisabled(
             [NotNull] IWebElementWrapper element, 
@@ -62,7 +62,7 @@ namespace Behavioral.Automation.Bindings
         {
             foreach (var row in table.Rows)
             {
-                var control = "\"" + row.Values.First() + "\" " + row.Values.Last();
+                var control = "the \"" + row.Values.First() + "\" " + row.Values.Last();
                 runnerAction($"{control} {behavior} {enabled}");
             }
         }


### PR DESCRIPTION
**Problem description:**
When we write the phrase that checks availability of several controls we get exception during execution of test.
_Example:_
```
Then the following controls should be disabled:
  --- table step argument ---
  | control name | type   |
  | Undo         | button |
  | Redo         | button |
```

_Result:_
-> No matching step definition found for the step. Use the following code to create one:
        [Then(@"""(.*)"" button should be disabled")]
        public void ThenButtonShouldBeDisabled(string undo)
        {
            _scenarioContext.Pending();
        }

