### PR TITLE
BAP-6: upgrade SpecFlow to version 3.4.31

### DIFF
--- a/Behavioral.Automation.DemoBindings/Behavioral.Automation.DemoBindings.csproj
+++ b/Behavioral.Automation.DemoBindings/Behavioral.Automation.DemoBindings.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="SpecFlow" Version="3.1.97" />
+    <PackageReference Include="SpecFlow" Version="3.4.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-	<PackageReference Include="SpecFlow" Version="3.1.97" />
+	<PackageReference Include="SpecFlow" Version="3.4.31" />
 	<PackageReference Include="SpecFlow.NUnit" Version="3.1.97" />
 	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/src/Behavioral.Automation/Behavioral.Automation.csproj
+++ b/src/Behavioral.Automation/Behavioral.Automation.csproj
@@ -30,7 +30,7 @@ The whole automation code is divided into the following parts:
       <PackageReference Include="NUnit" Version="3.12.0" />
       <PackageReference Include="Selenium.Support" Version="3.141.0" />
       <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-      <PackageReference Include="SpecFlow" Version="3.1.97" />
+      <PackageReference Include="SpecFlow" Version="3.4.31" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This upgrade fixes the problem with support of .Net Core > 3.1.102