### PR TITLE
BAP-56 Removed optional properties from IDropdownWrapper

### DIFF
--- a/src/Behavioral.Automation/Bindings/DropdownBinding.cs
+++ b/src/Behavioral.Automation/Bindings/DropdownBinding.cs
@@ -22,20 +22,12 @@ namespace Behavioral.Automation.Bindings
         [Then("the (.*?) should have the following values:")]
         public void CheckAllItems([NotNull] IDropdownWrapper wrapper, [NotNull] Table items)
         {
-            if (!wrapper.Autocomplete)
-            {
-                wrapper.Click();
-            }
             wrapper.Items.Should().BeEquivalentTo(items.Rows.Select(x => x.Values.Single()));
         }
 
         [Then("(.*?) should have the following groups:")]
-        public void CheckDropdownHeaders([NotNull] IDropdownWrapper wrapper, [NotNull] Table items)
+        public void CheckDropdownHeaders([NotNull] IGroupedDropdownWrapper wrapper, [NotNull] Table items)
         {
-            if (!wrapper.Autocomplete)
-            {
-                wrapper.Click();
-            }
             wrapper.GroupTexts.Should().BeEquivalentTo(items.Rows.Select(x => x.Values.Single()));
         }
 

--- a/src/Behavioral.Automation/Elements/IDropdownWrapper.cs
+++ b/src/Behavioral.Automation/Elements/IDropdownWrapper.cs
@@ -11,10 +11,6 @@ namespace Behavioral.Automation.Elements
 
         IEnumerable<string> Items { [NotNull, ItemNotNull] get; }
 
-        IEnumerable<string> GroupTexts { [NotNull, ItemNotNull] get; }
-
         bool Empty { get; }
-
-        bool Autocomplete { get; }
     }
 }

--- a/src/Behavioral.Automation/Elements/IGroupedDropdownWrapper.cs
+++ b/src/Behavioral.Automation/Elements/IGroupedDropdownWrapper.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Behavioral.Automation.Elements
+{
+    public interface IGroupedDropdownWrapper : IDropdownWrapper
+    {
+        IEnumerable<string> GroupTexts { [NotNull, ItemNotNull] get; }
+    }
+}


### PR DESCRIPTION
Since autocompletes and grouped dropdown options are not used across all our applications they were removed from IDropdownWrapper. Also click call was removed from binding and moved to wrapper implementation
In order to make wrappers work the following changes should be made in their project implementations

- Replace Elements property with the following one
```
` private IEnumerable<IWebElementWrapper> Items
        {
            get
            {
                if (!Autocomplete) //use if you have autocompletes in your app
                {
                    Click();
                }

                return Assert.ShouldGet(() => Elements.Select(x => x.Text).ToList());
            }
        }`
```

- Replace Select code with the following on
```
`public void Select(params string[] elements)
        {
            Assert.ShouldBecome(() => Displayed, true, 
                new AssertionBehavior(AssertionType.Continuous, false),
                $"{Caption} is not displayed");

            if (!Autocomplete) //use if you have autocompletes in your app
             {
                      Click();
             } 


            Assert.ShouldBecome(() => Stale, false, $"{Caption} is stale");
            
            Assert.ShouldBecome(
                () => elements.All(x => Elements.Any(y => y.Text == x)),
                true,
                new AssertionBehavior(AssertionType.Continuous, false),
                $"can not find elements \"{elements.Aggregate((x, y) => $"{x}, {y}")}\"");
            foreach (var element in elements)
            {
                Elements.Single(x => x.Text == element).Click();
            }
            Driver.CloseActiveElement();
        }`
```

- Move GroupTexts and GroupItems to the separate wrapper which implements IGroupedDropdownWrapperInterface (add click to GroupItems the same way as for elements if needed)