### PR TITLE
BAP-58: fix ListBinding and TableBinding

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -201,9 +201,22 @@ Then the following controls should be empty:
 
 ## List Binding
 
-* Check that list contains given values: 
-[Given("(.*?) (contain|not contain) the following items:")]
-[Then("(.*?) should (contain|contain in exact order|not contain) the following items:")]
+* Check that list has given values
+[Given("(.+?) (has|does not have) the following items:")]
+[Then("(.+?) should (have|not have) the following items:")]
+Example:
+Then "Categories" should have the following items:
+
+* Check that list has given values in exact order
+[Then("(.+?) should have in exact order the following items:")]
+Example:
+Then "Categories" should have in exact order the following items:
+
+* Check that list contains given values
+[Given("(.+?) (has|does not have) the following items:")]
+[Then("(.+?) should (have|not have) the following items:")]
+Example:
+Then "Categories" list should contain the following items:
 
 
 ## Navigation Binding
@@ -284,9 +297,18 @@ Example:
 When "Search results" grid has 5 items
 
 * Check that grid or table has given rows:
-[Given("(.*?) (contain|not contain) the following (rows|rows only):")]
-[Then("(.*?) should (contain|contain in exact order|not contain) the following (rows|rows only):")]
-[Then("(.*?) should (contain|not contain) \"(.*)\" in (.*)")]
+[Given("(.+?) (has|does not have) the following rows:")]
+[Then("(.+?) should (have|not have) the following rows:")]
+Example:
+Then "Search results" grid should have the following rows:
+
+[Then("(.+?) should have in exact order the following rows:")]
+Example:
+Then "Search results" grid should have in exact order the following rows:
+
+* Check that grid or table contains given rows:
+[Given("(.+?) (contains|does not contain) the following rows:")]
+[Then("(.+?) should (contain|not contain) the following rows:")]
 Example:
 Then "Search results" grid should contain the following rows:
 

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -213,8 +213,8 @@ Example:
 Then "Categories" should have in exact order the following items:
 
 * Check that list contains given values
-[Given("(.+?) (has|does not have) the following items:")]
-[Then("(.+?) should (have|not have) the following items:")]
+[Given("(.+?) (contains|does not contain) the following items:")]
+[Then("(.+?) should (contain|not contain) the following items:")]
 Example:
 Then "Categories" list should contain the following items:
 
@@ -311,6 +311,11 @@ Then "Search results" grid should have in exact order the following rows:
 [Then("(.+?) should (contain|not contain) the following rows:")]
 Example:
 Then "Search results" grid should contain the following rows:
+
+* Check that grid have specific value in column
+[Then("(.*?) should (have|not have) \"(.*)\" in (.*)")]
+Example:
+Then "Search results" grid should contain "Bob" in "Author" column
 
 * Check that numerical values in the table column are lesser or greater than the given value: 
 [Then("(.*?) values should be (lesser|greater) than \"(.*)\"")]

--- a/src/Behavioral.Automation/Bindings/ListBinding.cs
+++ b/src/Behavioral.Automation/Bindings/ListBinding.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using FluentAssertions;
 using Behavioral.Automation.Elements;
+using Behavioral.Automation.FluentAssertions;
 using Behavioral.Automation.Services;
 using JetBrains.Annotations;
 using TechTalk.SpecFlow;
@@ -17,25 +18,51 @@ namespace Behavioral.Automation.Bindings
             _driverService = driverService;
         }
 
-        [Given("(.*?) (contain|not contain) the following items:")]
-        [Then("(.*?) should (contain|contain in exact order|not contain) the following items:")]
-        public void CheckListContainsItems(IListWrapper list, string behavior, Table table)
+        [Given("(.+?) (has|does not have) the following items:")]
+        [Then("(.+?) should (have|not have) the following items:")]
+        public void CheckListHaveItems(IListWrapper list, string behavior,  Table table)
         {
             var expectedListValues = ListServices.TableToRowsList(table);
-
-            bool exactOrder = behavior.Contains("contain in exact order");
-
             bool checkResult;
-            if (behavior.StartsWith("not"))
+            if (behavior.Contains("not"))
             {
                 checkResult = list.ListValues.DoesntContainValues(expectedListValues);
             }
             else
             {
-                checkResult = list.ListValues.ContainsValues(expectedListValues, exactOrder);
+                Assert.ShouldBecome(() => list.ListValues.Count() == expectedListValues.Count, true,
+                    $"{list.Caption} has {list.ListValues.Count()} elements");
+
+                checkResult = list.ListValues.HaveValues(expectedListValues, false);
             }
+
             checkResult.Should().Be(true);
         }
 
+        [Given("(.+?) (contains|does not contain) the following items:")]
+        [Then("(.+?) should (contain|not contain) the following items:")]
+        public void CheckListContainsItems(IListWrapper list, string behavior, Table table)
+        {
+            var expectedListValues = ListServices.TableToRowsList(table);
+            bool checkResult;
+            if (behavior.Contains("not"))
+            {
+                checkResult = list.ListValues.DoesntContainValues(expectedListValues);
+            }
+            else
+            {
+                checkResult = list.ListValues.ContainsValues(expectedListValues);
+            }
+
+            checkResult.Should().Be(true);
+        }
+
+        [Then("(.+?) should have in exact order the following items:")]
+        public void CheckListContainsItemsInExactOrder(IListWrapper list,  Table table)
+        {
+            var expectedListValues = ListServices.TableToRowsList(table);
+            var checkResult = list.ListValues.HaveValues(expectedListValues, true);
+            checkResult.Should().Be(true);
+        }
     }
 }

--- a/src/Behavioral.Automation/Bindings/ListBinding.cs
+++ b/src/Behavioral.Automation/Bindings/ListBinding.cs
@@ -20,7 +20,7 @@ namespace Behavioral.Automation.Bindings
 
         [Given("(.+?) (has|does not have) the following items:")]
         [Then("(.+?) should (have|not have) the following items:")]
-        public void CheckListHaveItems(IListWrapper list, string behavior,  Table table)
+        public void CheckListHaveItems(IListWrapper list, string behavior, Table table)
         {
             var expectedListValues = ListServices.TableToRowsList(table);
             bool checkResult;

--- a/src/Behavioral.Automation/Bindings/ListBinding.cs
+++ b/src/Behavioral.Automation/Bindings/ListBinding.cs
@@ -58,7 +58,7 @@ namespace Behavioral.Automation.Bindings
         }
 
         [Then("(.+?) should have in exact order the following items:")]
-        public void CheckListContainsItemsInExactOrder(IListWrapper list,  Table table)
+        public void CheckListContainsItemsInExactOrder(IListWrapper list, Table table)
         {
             var expectedListValues = ListServices.TableToRowsList(table);
             var checkResult = list.ListValues.HaveValues(expectedListValues, true);

--- a/src/Behavioral.Automation/Bindings/TableBinding.cs
+++ b/src/Behavioral.Automation/Bindings/TableBinding.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using FluentAssertions;
 using Behavioral.Automation.Elements;
 using Behavioral.Automation.FluentAssertions;
-using Behavioral.Automation.Model;
 using Behavioral.Automation.Services;
 using TechTalk.SpecFlow;
 
@@ -20,16 +19,15 @@ namespace Behavioral.Automation.Bindings
             Assert.ShouldBecome(() => element.Rows.Count(), count, $"{element.Caption} has {element.Rows.Count()} rows");
         }
 
-        [Given("(.*?) (contain|not contain) the following (rows|rows only):")]
-        [Then("(.*?) should (contain|contain in exact order|not contain) the following (rows|rows only):")]
-        public void CheckTableContainsRows(ITableWrapper gridRows, string behavior, string strictCondition, Table table)
+        [Given("(.+?) (has|does not have) the following rows:")]
+        [Then("(.+?) should (have|not have) the following rows:")]
+        public void CheckTableHaveRows(ITableWrapper gridRows, string behavior, Table table)
         {
             var expectedValues = ListServices.TableToCellsList(table);
-            bool exactOrder = behavior.Contains("contain in exact order");
 
             Assert.ShouldBecome(() => gridRows.Stale, false, $"{gridRows.Caption} is stale");
 
-            bool inversion = behavior.StartsWith("not");
+            bool inversion = behavior.Contains("not");
             if (inversion)
             {
                 Assert.ShouldBecome(() => gridRows.CellsText.DoesntContainValues(expectedValues),
@@ -38,18 +36,52 @@ namespace Behavioral.Automation.Bindings
             }
             else
             {
-                if (strictCondition == "rows only")
-                {
-                    Assert.ShouldBecome(() => gridRows.CellsText.Count() == expectedValues.Count, true,
-                        $"{gridRows.Caption} is {gridRows.CellsText.Aggregate((x, y) => $"{x}, {y}")}");
-                }
-                Assert.ShouldBecome(() => gridRows.CellsText.ContainsValues(expectedValues, exactOrder),
-                true,
-                $"{gridRows.Caption} is {gridRows.CellsText.Aggregate((x, y) => $"{x}, {y}")}");
+                Assert.ShouldBecome(() => gridRows.CellsText.Count() == expectedValues.Count, true,
+                    $"{gridRows.Caption} is {gridRows.CellsText.Aggregate((x, y) => $"{x}, {y}")}");
+
+                Assert.ShouldBecome(() => gridRows.CellsText.HaveValues(expectedValues, false),
+                    true,
+                    $"{gridRows.Caption} is {gridRows.CellsText.Aggregate((x, y) => $"{x}, {y}")}");
             }
         }
 
-        [Then("(.*?) should (contain|not contain) \"(.*)\" in (.*)")]
+        [Then("(.+?) should have in exact order the following rows:")]
+        public void CheckTableHaveRowsInExactOrder(ITableWrapper gridRows, Table table)
+        {
+            var expectedValues = ListServices.TableToCellsList(table);
+
+            Assert.ShouldBecome(() => gridRows.Stale, false, $"{gridRows.Caption} is stale");
+
+            Assert.ShouldBecome(() => gridRows.CellsText.HaveValues(expectedValues, true),
+                true,
+                $"{gridRows.Caption} is {gridRows.CellsText.Aggregate((x, y) => $"{x}, {y}")}");
+        }
+
+        [Given("(.+?) (contains|does not contain) the following rows:")]
+        [Then("(.+?) should (contain|not contain) the following rows:")]
+        public void CheckTableContainsRows(ITableWrapper gridRows, string behavior,  Table table)
+        {
+            var expectedValues = ListServices.TableToCellsList(table);
+
+            Assert.ShouldBecome(() => gridRows.Stale, false, $"{gridRows.Caption} is stale");
+
+            bool inversion = behavior.Contains("not");
+            if (inversion)
+            {
+                Assert.ShouldBecome(() => gridRows.CellsText.DoesntContainValues(expectedValues),
+                    true,
+                    $"{gridRows.Caption} is {gridRows.CellsText.Aggregate((x, y) => $"{x}, {y}")}");
+            }
+            else
+            {
+
+                Assert.ShouldBecome(() => gridRows.CellsText.ContainsValues(expectedValues),
+                    true,
+                    $"{gridRows.Caption} is {gridRows.CellsText.Aggregate((x, y) => $"{x}, {y}")}");
+            }
+        }
+
+        [Then("(.*?) should (have|not have) \"(.*)\" in (.*)")]
         public void CheckTableContainRow(ITableWrapper table, string behavior, string value, IElementCollectionWrapper column)
         {
             Assert.ShouldBecome(() => column.Stale, false, $"{column.Caption} is stale");

--- a/src/Behavioral.Automation/Bindings/TableBinding.cs
+++ b/src/Behavioral.Automation/Bindings/TableBinding.cs
@@ -82,15 +82,15 @@ namespace Behavioral.Automation.Bindings
         }
 
         [Then("(.*?) should (have|not have) \"(.*)\" in (.*)")]
-        public void CheckTableContainRow(ITableWrapper table, string behavior, string value, IElementCollectionWrapper column)
+        public void CheckTableHaveValueInColumn(ITableWrapper table, string behavior, string value, IElementCollectionWrapper column)
         {
             Assert.ShouldBecome(() => column.Stale, false, $"{column.Caption} is stale");
             Assert.ShouldBecome(() => table.Text.Contains(value), true, $"{table.Caption} text is {table.Text}");
             Assert.ShouldBecome(() => column.Elements.Any(x => x.Stale), false, 
                 $"{table.Caption} elements are stale");
             ListServices.GetElementsTextsList(column.Elements).Contains(value).Should().Be(!behavior.Contains("not"));
-        }
-
+        } 
+         
         [Then("(.*?) values should be (lesser|greater) than \"(.*)\"")]
         public void CompareTableRowGreaterLesser(IElementCollectionWrapper column,  string condition,
             int value)

--- a/src/Behavioral.Automation/Services/ListServices.cs
+++ b/src/Behavioral.Automation/Services/ListServices.cs
@@ -91,7 +91,7 @@ namespace Behavioral.Automation.Services
                    list2.All(item => list1.Contains(item));
         }
 
-        public static bool ContainsValues(this IEnumerable<string> actualCollection, List<string> expectedValues, bool exactOrder)
+        public static bool HaveValues(this IEnumerable<string> actualCollection, List<string> expectedValues, bool exactOrder)
         {
             int index = 0;
             int maxIndexForValuesList = expectedValues.Count - 1;
@@ -102,20 +102,31 @@ namespace Behavioral.Automation.Services
                 {
                     return true;
                 }
-                bool collectionContainsValue = exactOrder ?
-                    expectedValues[index].Equals(value, StringComparison.Ordinal)
+
+                bool collectionContainsValue = exactOrder
+                    ? expectedValues[index].Equals(value, StringComparison.Ordinal)
                     : expectedValues.Contains(value, StringComparer.Ordinal);
                 if (!collectionContainsValue)
                 {
                     return false;
                 }
+
                 if (index == maxIndexForValuesList)
                 {
                     return true;
                 }
+
                 index++;
             }
+
             return false;
+        }
+
+        public static bool ContainsValues(this IEnumerable<string> actualCollection, List<string> expectedValues)
+        {
+            var intersection = expectedValues.Intersect(actualCollection).ToList();
+            var containsValues = intersection.SequenceEqual(expectedValues);
+            return containsValues;
         }
 
         public static bool DoesntContainValues(this IEnumerable<string> actualCollection, List<string> expectedValues)


### PR DESCRIPTION
This pull request fixes the problem with usage of contains keyword when checking tables and rows.
Now we have two separate keywords:
* have - means list/table should have only the specified rows 
* contains - means that list/table should have at least the specified rows