### PR TITLE
Fix typescript version for angular application

### DIFF
--- a/src/App/package-lock.json
+++ b/src/App/package-lock.json
@@ -10686,9 +10686,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.0.8",
+      "resolved": "https://monterosa-domain-158882446695.d.codeartifact.us-east-1.amazonaws.com:443/npm/monterosa-repo/typescript/-/typescript-4.0.8.tgz",
+      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/src/App/package.json
+++ b/src/App/package.json
@@ -33,6 +33,6 @@
     "@angular/cli": "^10.2.3",
     "@angular/compiler-cli": "^10.2.5",
     "@angular/language-service": "^10.2.5",
-    "typescript": "^4.2.4"
+    "typescript": "4.0.8"
   }
 }


### PR DESCRIPTION
An error occurs when trying to start Angular application:
`ERROR in The Angular Compiler requires TypeScript >=3.9.2 and <4.1.0 but 4.2.4 was found instead.`

Typescript version downgraded to the latest supported version by Angular 10.