### PR TITLE
Added Assert.ShouldBecome() with error message as a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[1.10.2] - 2022-05-16
+[1.11.0] - 2022-05-20
 ### Added
-- Fixed NullReferenceException when using ComplexBindingBuilder in hooks
+- Added Assert.ShouldBecome() with ability to pass error message as a function

--- a/src/Behavioral.Automation/Behavioral.Automation.csproj
+++ b/src/Behavioral.Automation/Behavioral.Automation.csproj
@@ -16,7 +16,7 @@ The whole automation code is divided into the following parts:
 - UI structure descriptive code
 - Supportive code</Description>
         <Copyright>Quantori Inc.</Copyright>
-        <PackageVersion>1.10.2</PackageVersion>
+        <PackageVersion>1.11.0</PackageVersion>
         <RepositoryUrl>https://github.com/quantori/Behavioral.Automation</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/Behavioral.Automation/Bindings/TableBinding.cs
+++ b/src/Behavioral.Automation/Bindings/TableBinding.cs
@@ -113,14 +113,14 @@ namespace Behavioral.Automation.Bindings
                 Assert.ShouldBecome(() => gridRows.Rows.ToStringRows().DoesntContainValues(table.Rows.ToStringRows()),
                     true,
                     new AssertionBehavior(AssertionType.Immediate, false),
-                    $"{gridRows.Caption} is: {gridRows.Rows.GetPrintableValues()}");
+                    () => $"{gridRows.Caption} is: {gridRows.Rows.GetPrintableValues()}");
             }
             else
             {
                 Assert.ShouldBecome(() => gridRows.Rows.ToStringRows().ContainsValues(table.Rows.ToStringRows(), false),
                     true,
                     new AssertionBehavior(AssertionType.Immediate, false),
-                    $"{gridRows.Caption} is: {gridRows.Rows.GetPrintableValues()}");
+                    () => $"{gridRows.Caption} is: {gridRows.Rows.GetPrintableValues()}");
             }
         }
         

--- a/src/Behavioral.Automation/FluentAssertions/Assert.cs
+++ b/src/Behavioral.Automation/FluentAssertions/Assert.cs
@@ -45,6 +45,19 @@ namespace Behavioral.Automation.FluentAssertions
             }
         }
 
+        public static void ShouldBecome<T>(this Func<T> predicate, T value, AssertionBehavior behavior, Func<string> message)
+        {
+            if (behavior.Type == AssertionType.Immediate)
+            {
+                var actualValue = TryGetValue(predicate, TimeSpan.FromMilliseconds(500));
+                True(actualValue.Equals(value) == !behavior.Inversion, message());
+            }
+            else
+            {
+                ShouldBecome(predicate, value, message, !behavior.Inversion);
+            }
+        }
+
         public static void ShouldBecome<T>(Func<T> predicate, T value, string message, bool direction = true, int attempts = DefaultAttempts)
         {
 
@@ -61,6 +74,25 @@ namespace Behavioral.Automation.FluentAssertions
             message ??= $"actual value is {actual}";
 
             True(actual.Equals(value) == direction, message);
+        }
+
+        public static void ShouldBecome<T>(Func<T> predicate, T value, Func<string> message, bool direction = true, int attempts = DefaultAttempts)
+        {
+
+            for (int index = 0; index < attempts; index++)
+            {
+                if (TryGetValue(predicate, TimeSpan.FromMilliseconds(500)).Equals(value) == direction)
+                {
+                    return;
+                }
+                Thread.Sleep(500);
+            }
+
+            var actual = TryGetValue(predicate, TimeSpan.FromMilliseconds(500));
+            var errorMessage = message();
+            errorMessage ??= $"actual value is {actual}";
+
+            True(actual.Equals(value) == direction, errorMessage);
         }
 
         public static void ShouldBe(IAssertionAccessor assertion, string caption, int attempts = DefaultAttempts)


### PR DESCRIPTION
These changes are intented to help to fix the following problem:
If we use Assert.ShouldBecome with interpolated string as error message, it's value is calculated BEFORE the actual ShouldBecome body, which can cause the problem, e.g. if Element is not loaded fully yet (in this case I've run into such problem with table). We need to allow to pass error message as a function and execute it only in the end, after the actual checking.