### PR TITLE
Added retry attempt if context switched too early

### DIFF
--- a/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="100.0.4896.6000" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6102" />
 	<PackageReference Include="SpecFlow" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.NUnit" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.69" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[1.11.0] - 2022-05-20
+[1.11.1] - 2022-06-08
 ### Added
-- Added Assert.ShouldBecome() with ability to pass error message as a function
+- Added retry attempt if context switched too early

--- a/src/Behavioral.Automation/Behavioral.Automation.csproj
+++ b/src/Behavioral.Automation/Behavioral.Automation.csproj
@@ -16,7 +16,7 @@ The whole automation code is divided into the following parts:
 - UI structure descriptive code
 - Supportive code</Description>
         <Copyright>Quantori Inc.</Copyright>
-        <PackageVersion>1.11.0</PackageVersion>
+        <PackageVersion>1.11.1</PackageVersion>
         <RepositoryUrl>https://github.com/quantori/Behavioral.Automation</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/Behavioral.Automation/Services/AutomationIDProvider.cs
+++ b/src/Behavioral.Automation/Services/AutomationIDProvider.cs
@@ -44,7 +44,6 @@ namespace Behavioral.Automation.Services
             Thread.Sleep(500);
             _scopeContextManager.SwitchToCurrentUrl(new Uri(_driverService.CurrentUrl));
 
-
             var scopeId = ((PageScopeContext)((ScopeContextRuntime)_scopeContextRuntime).CurrentContext).ScopeId;
             return _scopeContextRuntime.FindControlDescription(type, name) ??
                    throw new ArgumentException($"Control with alias=\"{type}\" and caption=\"{name}\" not found in PageContext with urlWildcard=\"{scopeId.UrlWildCard}\"");

--- a/src/Behavioral.Automation/Services/Mapping/PageScopeContext.cs
+++ b/src/Behavioral.Automation/Services/Mapping/PageScopeContext.cs
@@ -44,8 +44,7 @@ namespace Behavioral.Automation.Services.Mapping
                 }
             }
 
-            throw new ArgumentException(
-                    $"Control with alias=\"{type}\" and caption=\"{name}\" not found in PageContext with urlWildcard=\"{ScopeId.UrlWildCard}\"");
+            return null;
         }
 
         public IControlScopeContext GetNestedControlScopeContext(ControlScopeId controlScopeId)


### PR DESCRIPTION
These changes are intended to help to fix the following problem:

sometimes context is switched too early and UI elements are searched on the wrong page