### PR TITLE
Fix NullReferenceException in StepParamatersProcessor.cs

### DIFF
--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.127" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="106.0.5249.6100" />
 	<PackageReference Include="SpecFlow" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.NUnit" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.69" />

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="106.0.5249.6100" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.127" />
 	<PackageReference Include="SpecFlow" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.NUnit" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.69" />

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="103.0.5060.13400" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="106.0.5249.6100" />
 	<PackageReference Include="SpecFlow" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.NUnit" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.69" />

--- a/Behavioral.Automation.Selenium/Behavioral.Automation/Behavioral.Automation.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation/Behavioral.Automation.csproj
@@ -16,7 +16,7 @@ The whole automation code is divided into the following parts:
 - UI structure descriptive code
 - Supportive code</Description>
         <Copyright>Quantori Inc.</Copyright>
-        <PackageVersion>1.15.1</PackageVersion>
+        <PackageVersion>1.15.2</PackageVersion>
         <RepositoryUrl>https://github.com/quantori/Behavioral.Automation</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>

--- a/Behavioral.Automation.Selenium/Behavioral.Automation/Services/StepParametersProcessor.cs
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation/Services/StepParametersProcessor.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Behavioral.Automation.Elements;
 using Behavioral.Automation.Model;
 using TechTalk.SpecFlow;
+using TechTalk.SpecFlow.Bindings;
 
 namespace Behavioral.Automation.Services
 {
@@ -76,18 +77,27 @@ namespace Behavioral.Automation.Services
 
         private string BuildBehaviourString(AssertionBehavior b)
         {
-            var currentStepType = _scenarioContext.StepContext.StepInfo.StepDefinitionType;
+            StepDefinitionType currentStepType;
+            try
+            {
+                currentStepType = _scenarioContext.StepContext.StepInfo.StepDefinitionType;
+            }
+            catch (NullReferenceException)
+            {
+                currentStepType = StepDefinitionType.Given;
+            }
+            
             string behaviorString = string.Empty;
             if (b.Type == AssertionType.Immediate)
             {
                 switch (currentStepType)
                 {
-                    case TechTalk.SpecFlow.Bindings.StepDefinitionType.Given:
-                    case TechTalk.SpecFlow.Bindings.StepDefinitionType.When:
+                    case StepDefinitionType.Given:
+                    case StepDefinitionType.When:
                         behaviorString = "is";
                         break;
 
-                    case TechTalk.SpecFlow.Bindings.StepDefinitionType.Then:
+                    case StepDefinitionType.Then:
                         behaviorString = "be";
                         break;
                 }

--- a/src/BlazorApp/BlazorApp.csproj
+++ b/src/BlazorApp/BlazorApp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.127" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="106.0.5249.6100" />
   </ItemGroup>
 
 </Project>

--- a/src/BlazorApp/BlazorApp.csproj
+++ b/src/BlazorApp/BlazorApp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="106.0.5249.6100" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.127" />
   </ItemGroup>
 
 </Project>

--- a/src/BlazorApp/BlazorApp.csproj
+++ b/src/BlazorApp/BlazorApp.csproj
@@ -7,4 +7,8 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="106.0.5249.6100" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes NullReferenceException when complexBindingBuilder with AssertionBehavior is run from hooks.

_AutotestsRun (push) fails, because of chromedriver version, it waits for the older version._