### PR TITLE
Update ChromeDriver version to 133 for Selenium tests

### DIFF
--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="123.0.6312.8600" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="133.0.6943.14100" />
 	<PackageReference Include="SpecFlow" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.NUnit" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.69" />


### PR DESCRIPTION
This PR updates the ChromeDriver version to 133 to ensure compatibility with the latest Chrome browser