### PR TITLE
Upgrade .NET to 8.0 to fix Playwright Test cases

### DIFF
--- a/.github/workflows/PlaywrightProjectTests.yml
+++ b/.github/workflows/PlaywrightProjectTests.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET Core SDK '5.0.x'
-        uses: actions/setup-dotnet@v3
+      - name: Setup .NET Core SDK '8.0.x'
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '8.0.x'
       - name: Run Blazor app
         run: |
           cd ./src/BlazorApp

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -17,9 +17,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
           include-prerelease: true
       - name: restore packages
         run: dotnet restore

--- a/.github/workflows/SeleniumProjectTests.yaml
+++ b/.github/workflows/SeleniumProjectTests.yaml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/Behavioral.Automation.AsyncAbstractions.UI/Behavioral.Automation.AsyncAbstractions.UI.csproj
+++ b/Behavioral.Automation.AsyncAbstractions.UI/Behavioral.Automation.AsyncAbstractions.UI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Platforms>AnyCPU</Platforms>

--- a/Behavioral.Automation.Configs/Behavioral.Automation.Configs.csproj
+++ b/Behavioral.Automation.Configs/Behavioral.Automation.Configs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Platforms>AnyCPU</Platforms>

--- a/Behavioral.Automation.Playwright/Behavioral.Automation.Playwright/Behavioral.Automation.Playwright.csproj
+++ b/Behavioral.Automation.Playwright/Behavioral.Automation.Playwright/Behavioral.Automation.Playwright.csproj
@@ -22,7 +22,7 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/Behavioral.Automation.Playwright/UITests/UITests.csproj
+++ b/Behavioral.Automation.Playwright/UITests/UITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Authors>Quantori Inc.</Authors>
         <Description>Specflow scenarios for demonstration of Behavioral.Automation framework features and testing.</Description>
         <Copyright>Quantori Inc.</Copyright>

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoBindings/Behavioral.Automation.DemoBindings.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoBindings/Behavioral.Automation.DemoBindings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<IsPackable>false</IsPackable>
 	<Authors>Quantori Inc.</Authors>
 	<Description>Demo project that can be used as example of test configuration.</Description>

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Quantori Inc.</Authors>
     <Description>Specflow scenarios for demonstration of Behavioral.Automation framework features and testing.</Description>
     <Copyright>Quantori Inc.</Copyright>

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios/Behavioral.Automation.DemoScenarios.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="123.0.6312.8600" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="133.0.6943.14100" />
 	<PackageReference Include="SpecFlow" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.NUnit" Version="3.9.69" />
 	<PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.69" />

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.Template/Behavioral.Automation.Template.Bindings/Behavioral.Automation.Template.Bindings.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.Template/Behavioral.Automation.Template.Bindings/Behavioral.Automation.Template.Bindings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>Quantori Inc.</Authors>
     <Description>Demo project that can be used as example of test configuration.</Description>

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.Template/Behavioral.Automation.Template.Scenarios/Behavioral.Automation.Template.Scenarios.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.Template/Behavioral.Automation.Template.Scenarios/Behavioral.Automation.Template.Scenarios.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>net8.0</TargetFramework>
     <Authors>Quantori Inc.</Authors>
     <Description>Specflow scenarios for demonstration of Behavioral.Automation framework features and testing.</Description>
     <Copyright>Quantori Inc.</Copyright>

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.UnitTests/Behavioral.Automation.UnitTests.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.UnitTests/Behavioral.Automation.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Behavioral.Automation.Selenium/Behavioral.Automation/Behavioral.Automation.csproj
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation/Behavioral.Automation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Quantori Inc.</Authors>
         <Description>Platform design is based on strong and well-defined borderline between procedural test cases structure and object-oriented code-behind.

--- a/src/BlazorApp/BlazorApp.csproj
+++ b/src/BlazorApp/BlazorApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
This PR upgrades the .NET version to 8.0 to resolve issues with Playwright test cases and ensure better compatibility and performance.