### PR TITLE
Chore: Improve logging for NuGet release

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -45,4 +45,11 @@ jobs:
       - name: Publish app into nuget.org
         env:
           NUGET_API_KEY: ${{ secrets.QUANTORI_NUGET_API_KEY }}
-        run: dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate
+        run: |
+          if dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate 2>&1 | tee output.log | grep -q "403"; then
+            echo "NError: NuGet API key is invalid or expired. Please contact Quantori support to renew the key. For more details, refer to the Quantori BDD Confluence page called 'Renew NuGet API key'."
+          exit 1
+          else
+            echo "Package successfully published to NuGet.org."
+          fi
+          

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -45,12 +45,10 @@ jobs:
       - name: Publish app into nuget.org
         env:
           NUGET_API_KEY: ${{ secrets.QUANTORI_NUGET_API_KEY }}
-        run: |
-          exit_code=0
-          output=$(dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate 2>&1) || {
-            echo "An error occurred while running the dotnet nuget push command."
-            exit_code=1
-          }
+        run: |          
+          output=$(dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate 2>&1) || exit_code=$?
+
+          if [ -z "$exit_code" ]; then exit_code=0; fi
 
           echo "$output"
           echo "Exit Code: $exit_code"
@@ -59,8 +57,8 @@ jobs:
             echo "Error: NuGet API key is invalid or expired. Please contact Quantori support to renew the key. For more details, refer to the Quantori BDD Confluence page called 'Renew NuGet API key'."
             exit 1
           elif [ $exit_code -ne 0 ]; then
-            echo "Error: dotnet nuget push failed. Check the logs for more details."
-            exit 1
+            echo "Error: dotnet nuget push failed with exit code $exit_code. Check the logs for more details."
+            exit $exit_code
           else
             echo "Package successfully published to NuGet.org."
           fi

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -46,9 +46,21 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.QUANTORI_NUGET_API_KEY }}
         run: |
-          if dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate 2>&1 | tee /dev/stderr | grep -q "403"; then
+          exit_code=0
+          output=$(dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate 2>&1) || {
+            echo "An error occurred while running the dotnet nuget push command."
+            exit_code=1
+          }
+
+          echo "$output"
+          echo "Exit Code: $exit_code"
+
+          if echo "$output" | grep -q "403"; then
             echo "Error: NuGet API key is invalid or expired. Please contact Quantori support to renew the key. For more details, refer to the Quantori BDD Confluence page called 'Renew NuGet API key'."
-          exit 1
+            exit 1
+          elif [ $exit_code -ne 0 ]; then
+            echo "Error: dotnet nuget push failed. Check the logs for more details."
+            exit 1
           else
             echo "Package successfully published to NuGet.org."
           fi

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -47,7 +47,7 @@ jobs:
           NUGET_API_KEY: ${{ secrets.QUANTORI_NUGET_API_KEY }}
         run: |
           if dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate 2>&1 | tee /dev/stderr | grep -q "403"; then
-            echo "NError: NuGet API key is invalid or expired. Please contact Quantori support to renew the key. For more details, refer to the Quantori BDD Confluence page called 'Renew NuGet API key'."
+            echo "Error: NuGet API key is invalid or expired. Please contact Quantori support to renew the key. For more details, refer to the Quantori BDD Confluence page called 'Renew NuGet API key'."
           exit 1
           else
             echo "Package successfully published to NuGet.org."

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -46,7 +46,7 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.QUANTORI_NUGET_API_KEY }}
         run: |
-          if dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate 2>&1 | tee output.log | grep -q "403"; then
+          if dotnet nuget push ./Behavioral.Automation.${{ env.VER }}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_API_KEY" --skip-duplicate 2>&1 | tee /dev/stderr | grep -q "403"; then
             echo "NError: NuGet API key is invalid or expired. Please contact Quantori support to renew the key. For more details, refer to the Quantori BDD Confluence page called 'Renew NuGet API key'."
           exit 1
           else


### PR DESCRIPTION
This PR adds an explicit error message when a 403 response is received, indicating an invalid or expired NuGet API key. This will help users quickly identify issues with the API key and understand how to resolve them. Additionally, a success message is displayed when the package is successfully published to NuGet.org.

Error example if NuGet key is expired:
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/a0ce1428-c3f3-468e-a3c1-0b1178385cd9" />
