### PR TITLE
Allow Selection of a Runner in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/PlaywrightProjectTests.yml
+++ b/.github/workflows/PlaywrightProjectTests.yml
@@ -2,13 +2,22 @@ name: Playwright project tests
 
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Select the runner"
+        required: false
+        type: choice
+        options:
+          - ubunntu-latest
+          - windows-latest
+        default: ubunntu-latest
   pull_request:
 
 jobs:
   PlaywrightProjectTests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'ubunntu-latest' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup .NET Core SDK '8.0.x'
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/PlaywrightProjectTests.yml
+++ b/.github/workflows/PlaywrightProjectTests.yml
@@ -8,14 +8,14 @@ on:
         required: false
         type: choice
         options:
-          - ubunntu-latest
+          - ubuntu-latest
           - windows-latest
         default: ubunntu-latest
   pull_request:
 
 jobs:
   PlaywrightProjectTests:
-    runs-on: ${{ inputs.runner || 'ubunntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET Core SDK '8.0.x'

--- a/.github/workflows/SeleniumProjectTests.yaml
+++ b/.github/workflows/SeleniumProjectTests.yaml
@@ -2,6 +2,15 @@ name: Selenium project tests
 
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Select the runner"
+        required: false
+        type: choice
+        options:
+          - windows-latest
+          - ubunntu-latest
+        default: windows-latest
   pull_request:
     branches: [ main ]
     
@@ -11,10 +20,10 @@ env:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ${{ inputs.runner || 'windows-latest' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/SeleniumProjectTests.yaml
+++ b/.github/workflows/SeleniumProjectTests.yaml
@@ -9,7 +9,7 @@ on:
         type: choice
         options:
           - windows-latest
-          - ubunntu-latest
+          - ubuntu-latest
         default: windows-latest
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
This update modifies the GHA workflow to allow users to select a specific runner when triggering the workflow manually via workflow_dispatch. 