### PR TITLE
Make GHA tests cross-platform

### DIFF
--- a/.github/workflows/PlaywrightProjectTests.yml
+++ b/.github/workflows/PlaywrightProjectTests.yml
@@ -10,7 +10,7 @@ on:
         options:
           - ubuntu-latest
           - windows-latest
-        default: ubunntu-latest
+        default: ubuntu-latest
   pull_request:
 
 jobs:
@@ -18,15 +18,28 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET Core SDK '8.0.x'
+
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-      - name: Run Blazor app
+
+      # Windows Runner
+      - name: Run Blazor app (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath dotnet -ArgumentList "run" -WorkingDirectory ./src/BlazorApp }
+          Start-Sleep -Seconds 20
+
+      # Ubuntu Runner
+      - name: Run Blazor app (Ubuntu)
+        if: runner.os == 'Linux'
         run: |
           cd ./src/BlazorApp
           dotnet run &
+
       - name: Test Blazor app
         run: |
           cd ./Behavioral.Automation.Playwright/UITests
           dotnet test
+

--- a/.github/workflows/SeleniumProjectTests.yaml
+++ b/.github/workflows/SeleniumProjectTests.yaml
@@ -28,6 +28,21 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+
+      # Windows Runner
+      - name: Run Blazor app (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath dotnet -ArgumentList "run" -WorkingDirectory ./src/BlazorApp }
+          Start-Sleep -Seconds 20
+
+      # Ubuntu Runner
+      - name: Run Blazor app (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          cd ./src/BlazorApp
+          dotnet run &
+
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -36,3 +51,4 @@ jobs:
       - name: Test
         working-directory: ./Behavioral.Automation.Selenium/Behavioral.Automation.DemoScenarios
         run: dotnet test -c Release --no-build --verbosity normal
+

--- a/.github/workflows/SeleniumProjectTests.yaml
+++ b/.github/workflows/SeleniumProjectTests.yaml
@@ -13,9 +13,6 @@ on:
         default: windows-latest
   pull_request:
     branches: [ main ]
-    
-env:
-  BROWSER_PARAMS: "--window-size=1920,1080 --allowed-ips --no-sandbox"
 
 jobs:
   build:

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoBindings/AutomationConfig.json
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoBindings/AutomationConfig.json
@@ -1,6 +1,6 @@
 ﻿{
   "BASE_URL": "http://localhost:4200/",
-  "BROWSER_PARAMS": "--window-size=1920,1080",
+  "BROWSER_PARAMS": "--window-size=1920,1080 --allowed-ips --no-sandbox --headless",
   "ACCESS_CLIPBOARD": false, 
   "DOWNLOAD_PATH": "",
   "SEARCH_ATTRIBUTE": "data-automation-id",

--- a/Behavioral.Automation.Selenium/Behavioral.Automation.DemoBindings/Bootstrapper.cs
+++ b/Behavioral.Automation.Selenium/Behavioral.Automation.DemoBindings/Bootstrapper.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Net;
-using Behavioral.Automation.Configs;
-using Behavioral.Automation.FluentAssertions;
+﻿using Behavioral.Automation.FluentAssertions;
 using Behavioral.Automation.Services;
 using BoDi;
 using TechTalk.SpecFlow;
@@ -17,7 +12,6 @@ namespace Behavioral.Automation.DemoBindings
         private readonly ITestRunner _runner;
         private readonly DemoTestServicesBuilder _servicesBuilder;
         private readonly BrowserRunner _browserRunner;
-        private static Process _coreRunProcess;
         
         public Bootstrapper(IObjectContainer objectContainer, ITestRunner runner, BrowserRunner browserRunner)
         {
@@ -25,53 +19,6 @@ namespace Behavioral.Automation.DemoBindings
             _runner = runner;
             _browserRunner = browserRunner;
             _servicesBuilder = new DemoTestServicesBuilder(objectContainer, new TestServicesBuilder(_objectContainer));
-        }
-
-        private static bool IsConnectionEstablished()
-        {
-            try
-            {
-                WebRequest.CreateHttp(ConfigManager.GetConfig<Config>().BaseUrl).GetResponse();
-                return true;
-            }
-            catch (WebException)
-            {
-                return false;
-            }
-        }
-
-        private static void RunTestApp()
-        {
-            string testAppPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..", "src",
-                "BlazorApp");
-
-            _coreRunProcess = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "cmd.exe",
-                    Arguments = "/c dotnet run",
-                    WorkingDirectory = testAppPath
-                }
-            };
-            _coreRunProcess.Start();
-        }
-
-        [BeforeTestRun]
-        public static void StartDemoApp()
-        {
-            if (!IsConnectionEstablished())
-                RunTestApp();
-        }
-
-        [AfterTestRun]
-        public static void StopDemoApp()
-        {
-            if (_coreRunProcess != null)
-            {
-                _coreRunProcess.Kill(true);
-                _coreRunProcess.Dispose();
-            }
         }
 
         [AfterScenario]


### PR DESCRIPTION
Previously, GitHub Actions tests were platform-dependent (Selenium only on windows runners, playwright only on ubuntu runners), and for selenium tests the SUT was spined up in a before-launch hook, making the process less transparent. This PR moves the SUT run script to a dedicated GHA workflow step